### PR TITLE
Implement App2App redirection

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.10" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -21,7 +21,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -21,7 +21,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Pass your ViewModel, using the `viewModels` function, and pass it to the `XS2AWi
 > It is possible to freely define the ViewModel-Scope.
 > Please refer to [this answer](https://stackoverflow.com/a/68971296) for more information.
 
-## App to App redirection
+## App to App redirection (Beta)
 Some banks support redirecting to their banking app.
 Per default the SDK will not redirect to the banking app and opens the internal WebView instead.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,52 @@ Pass your ViewModel, using the `viewModels` function, and pass it to the `XS2AWi
 > It is possible to freely define the ViewModel-Scope.
 > Please refer to [this answer](https://stackoverflow.com/a/68971296) for more information.
 
+## App to App redirection
+Some banks support redirecting to their banking app.
+Per default the SDK will not redirect to the banking app and opens the internal WebView instead.
+
+If you'd like to make use of this feature you can configure the SDK the following way:
+
+Modify your `AndroidManifest.xml` with the following:
+
+```xml
+<activity
+    android:exported="true" // Required
+    android:launchMode="singleInstance" // Required, other values might be used as well.
+    ...>
+    ...
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:host="<host>"
+            android:scheme="<scheme>" />
+    </intent-filter>
+</activity>
+```
+
+Populate `host` and `scheme` with your the URL of your App.
+
+After that just pass your URL to the SDK:
+
+```kotlin
+// Compose
+XS2AWizard(
+    sessionKey = <your-session-key>,
+    redirectDeepLink = "<scheme>://<host>" // Insert your deep link
+)
+
+// Fragment
+XS2AWizardFragment(
+    sessionKey = <your-session-key>,
+    redirectDeepLink = "<scheme>://<host>" // Insert your deep link
+)
+```
+
+Now every time the SDK encounters an URL to a bank which is known by us to support App2App redirection, the user gets asked if they want
+to perform the action within the WebView or the banking app.
+
 #### Example
 
 ```kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 GROUP=com.fintecsystems
-VERSION_NAME=5.1.4
+VERSION_NAME=5.2.0
 POM_URL=https://github.com/FinTecSystems/xs2a-android
 POM_SCM_URL=git@github.com:FinTecSystems/xs2a-android.git
 POM_SCM_CONNECTION=scm:git:git@github.com:FinTecSystems/xs2a-android.git

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
@@ -66,6 +66,7 @@ fun XS2AWizard(
     enableBackButton: Boolean = true,
     enableAutomaticRetry: Boolean = true,
     callbackListener: XS2AWizardCallbackListener? = null,
+    redirectUrl: String? = null,
     xs2aWizardViewModel: XS2AWizardViewModel = viewModel()
 ) {
     val form by xs2aWizardViewModel.form.observeAsState(null)
@@ -86,6 +87,7 @@ fun XS2AWizard(
             enableScroll,
             enableBackButton,
             enableAutomaticRetry,
+            redirectUrl,
             context as Activity
         )
 

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
@@ -52,6 +52,9 @@ import com.fintecsystems.xs2awizard.form.components.textLine.TextLine
  * @param enableAutomaticRetry - If true requests to the backend will be retried if the device is offline and goes online again.
  *                               This also means that the loading indicator will stay during that time.
  * @param callbackListener - Listener to all XS2A callbacks.
+ * @param redirectDeepLink - Deep Link of Host-App used for returning App2App redirection.
+ *                           Must match your scheme and host declared in your AndroidManifest.
+ *                           e.g "<scheme>://<host>".
  * @param xs2aWizardViewModel - ViewModel of the Wizard-Instance.
  */
 @Composable

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/XS2AWizard.kt
@@ -66,7 +66,7 @@ fun XS2AWizard(
     enableBackButton: Boolean = true,
     enableAutomaticRetry: Boolean = true,
     callbackListener: XS2AWizardCallbackListener? = null,
-    redirectUrl: String? = null,
+    redirectDeepLink: String? = null,
     xs2aWizardViewModel: XS2AWizardViewModel = viewModel()
 ) {
     val form by xs2aWizardViewModel.form.observeAsState(null)
@@ -87,7 +87,7 @@ fun XS2AWizard(
             enableScroll,
             enableBackButton,
             enableAutomaticRetry,
-            redirectUrl,
+            redirectDeepLink,
             context as Activity
         )
 

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardBundleKeys.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardBundleKeys.kt
@@ -11,7 +11,7 @@ object XS2AWizardBundleKeys {
     const val enableScroll = "enableScroll"
     const val enableBackButton = "enableBackButton"
     const val enableAutomaticRetry = "enableAutomaticRetry"
-    const val redirectURL = "redirectURL"
+    const val redirectDeepLink = "redirectDeepLink"
 
     const val currentWebViewUrl = "currentWebViewUrl"
 }

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardBundleKeys.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardBundleKeys.kt
@@ -11,6 +11,7 @@ object XS2AWizardBundleKeys {
     const val enableScroll = "enableScroll"
     const val enableBackButton = "enableBackButton"
     const val enableAutomaticRetry = "enableAutomaticRetry"
+    const val redirectURL = "redirectURL"
 
     const val currentWebViewUrl = "currentWebViewUrl"
 }

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -622,7 +622,7 @@ class XS2AWizardViewModel(
      * @param url the URL to open.
      */
     internal fun openRedirectURL(url: String) {
-        if (supportsAppRedirection(url)) {
+        if (urlSupportsAppRedirection(url)) {
             openExternalUrl(url)
         } else {
             openWebView(url)
@@ -647,8 +647,8 @@ class XS2AWizardViewModel(
      * @param url URL to check
      * @return true if URL supports App2App redirection
      */
-    private fun supportsAppRedirection(url: String) =
-        supportedAppRedirectionProviders.contains(url.toUri().host)
+    private fun urlSupportsAppRedirection(url: String) =
+        supportedAppRedirectionURLs.contains(url.toUri().host)
 
     /**
      * Checks if provided [url] is the [redirectURL].
@@ -664,7 +664,7 @@ class XS2AWizardViewModel(
         private const val storedProvidersKey = "providers"
         private const val masterKeyAlias = "xs2a_credentials_master_key"
 
-        private val supportedAppRedirectionProviders = listOf(
+        private val supportedAppRedirectionURLs = listOf(
             "manage.xs2a.com",
             "myaccount.ing.com"
         )

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -64,6 +64,12 @@ class XS2AWizardViewModel(
      */
     private var enableAutomaticRetry: Boolean = true
 
+    /**
+     * Used for App2App redirection.
+     * URL of Host-App to return to.
+     */
+    private var redirectURL: String? = null
+
     internal val form = MutableLiveData<List<FormLineData>?>()
 
     internal val loadingIndicatorLock = MutableLiveData(false)
@@ -120,12 +126,14 @@ class XS2AWizardViewModel(
         enableScroll: Boolean,
         enableBackButton: Boolean,
         enableAutomaticRetry: Boolean,
+        redirectURL: String?,
         activity: Activity
     ) {
         this.language = language
         this.enableScroll = enableScroll
         this.enableBackButton = enableBackButton
         this.enableAutomaticRetry = enableAutomaticRetry
+        this.redirectURL = redirectURL
         currentActivity = WeakReference(activity)
 
         NetworkingInstance.getInstance(context).apply {
@@ -148,6 +156,7 @@ class XS2AWizardViewModel(
         enableScroll = true
         enableBackButton = true
         enableAutomaticRetry = true
+        redirectURL = null
         currentActivity = WeakReference(null)
         connectionState.value = ConnectionState.UNKNOWN
         context.unregisterNetworkCallback(networkCallback)

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -650,6 +650,14 @@ class XS2AWizardViewModel(
     private fun supportsAppRedirection(url: String) =
         supportedAppRedirectionProviders.contains(url.toUri().host)
 
+    /**
+     * Checks if provided [url] is the [redirectURL].
+     *
+     * @param url URL to check
+     * @return true if it's the [redirectURL]
+     */
+    internal fun isRedirectURL(url: String) = url == redirectURL
+
     companion object {
         private const val rememberLoginName = "store_credentials"
         private const val sharedPreferencesFileName = "xs2a_credentials"

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -172,6 +172,10 @@ class XS2AWizardViewModel(
         buildJsonObject {
             put("version", JsonPrimitive(BuildConfig.VERSION))
             put("client", JsonPrimitive(context.getString(R.string.xs2a_client_tag)))
+
+            if (redirectURL != null) {
+                put("location", JsonPrimitive(redirectURL))
+            }
         },
         true
     )

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -657,7 +657,8 @@ class XS2AWizardViewModel(
         private const val masterKeyAlias = "xs2a_credentials_master_key"
 
         private val supportedAppRedirectionProviders = listOf(
-            "api.xs2a.com"
+            "manage.xs2a.com",
+            "myaccount.ing.com"
         )
 
         /**

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -73,7 +73,7 @@ class XS2AWizardViewModel(
      * Used for App2App redirection.
      * URL of Host-App to return to.
      */
-    private var redirectURL: String? = null
+    private var redirectDeepLink: String? = null
 
     internal val form = MutableLiveData<List<FormLineData>?>()
 
@@ -112,7 +112,7 @@ class XS2AWizardViewModel(
     private val onNewIntentListener = Consumer<Intent> {
         if (it.action != Intent.ACTION_VIEW || it.data == null) return@Consumer
 
-        if (it.dataString == redirectURL) {
+        if (isRedirectDeepLink(it.dataString)) {
             redirectionCallback(true)
         }
     }
@@ -139,14 +139,14 @@ class XS2AWizardViewModel(
         enableScroll: Boolean,
         enableBackButton: Boolean,
         enableAutomaticRetry: Boolean,
-        redirectURL: String?,
+        redirectDeepLink: String?,
         activity: Activity
     ) {
         this.language = language
         this.enableScroll = enableScroll
         this.enableBackButton = enableBackButton
         this.enableAutomaticRetry = enableAutomaticRetry
-        this.redirectURL = redirectURL
+        this.redirectDeepLink = redirectDeepLink
         currentActivity = WeakReference(activity)
 
         NetworkingInstance.getInstance(context).apply {
@@ -171,7 +171,7 @@ class XS2AWizardViewModel(
         enableScroll = true
         enableBackButton = true
         enableAutomaticRetry = true
-        redirectURL = null
+        redirectDeepLink = null
         (currentActivity.get() as? ComponentActivity)?.removeOnNewIntentListener(
             onNewIntentListener
         )
@@ -191,8 +191,8 @@ class XS2AWizardViewModel(
             put("version", JsonPrimitive(BuildConfig.VERSION))
             put("client", JsonPrimitive(context.getString(R.string.xs2a_client_tag)))
 
-            if (redirectURL != null) {
-                put("location", JsonPrimitive(redirectURL))
+            if (redirectDeepLink != null) {
+                put("location", JsonPrimitive(redirectDeepLink))
             }
         },
         true
@@ -677,12 +677,12 @@ class XS2AWizardViewModel(
         supportedAppRedirectionURLs.contains(url.toUri().host)
 
     /**
-     * Checks if provided [url] is the [redirectURL].
+     * Checks if provided [url] is the [redirectDeepLink].
      *
      * @param url URL to check
-     * @return true if it's the [redirectURL]
+     * @return true if it's the [redirectDeepLink]
      */
-    internal fun isRedirectURL(url: String) = url == redirectURL
+    internal fun isRedirectDeepLink(url: String?) = url == redirectDeepLink
 
     /**
      * Callback method for the redirection result.

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -640,11 +640,12 @@ class XS2AWizardViewModel(
     internal fun openRedirectURL(url: String) {
         if (urlSupportsAppRedirection(url)) {
             AlertDialog.Builder(currentActivity.get()!!).apply {
-                setMessage("Open in WebView or external App?")
-                setPositiveButton("External App") { _, _ ->
+                setTitle(R.string.redirect_dialog_title)
+                setMessage(R.string.redirect_dialog_message)
+                setPositiveButton(R.string.redirect_dialog_banking_app_button_title) { _, _ ->
                     openExternalUrl(url)
                 }
-                setNegativeButton("WebView") { _, _ ->
+                setNegativeButton(R.string.redirect_dialog_website_button_title) { _, _ ->
                     openWebView(url)
                 }
                 show()

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
@@ -161,6 +161,13 @@ fun URLBarWebView(viewModel: XS2AWizardViewModel) {
                     webViewClient = object : WebViewClient() {
                         @Deprecated("Deprecated in Java")
                         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                            if (viewModel.isRedirectURL(url)) {
+                                viewModel.closeWebView()
+                                viewModel.submitForm("post-code")
+
+                                return true
+                            }
+
                             currentUrl = url
                             view.loadUrl(url)
                             return true

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
@@ -54,10 +54,7 @@ fun URLBarWebView(viewModel: XS2AWizardViewModel) {
     val callbackHandler = object : XS2AJavascriptInterfaceCallback {
         override fun xS2AJavascriptInterfaceCallbackHandler(success: Boolean) {
             coroutineScope.launch {
-                viewModel.closeWebView()
-
-                if (success)
-                    viewModel.submitForm("post-code")
+                viewModel.redirectionCallback(success)
             }
         }
     }
@@ -162,9 +159,7 @@ fun URLBarWebView(viewModel: XS2AWizardViewModel) {
                         @Deprecated("Deprecated in Java")
                         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
                             if (viewModel.isRedirectURL(url)) {
-                                viewModel.closeWebView()
-                                viewModel.submitForm("post-code")
-
+                                viewModel.redirectionCallback(true)
                                 return true
                             }
 

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/webview/URLBarWebView.kt
@@ -158,7 +158,7 @@ fun URLBarWebView(viewModel: XS2AWizardViewModel) {
                     webViewClient = object : WebViewClient() {
                         @Deprecated("Deprecated in Java")
                         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
-                            if (viewModel.isRedirectURL(url)) {
+                            if (viewModel.isRedirectDeepLink(url)) {
                                 viewModel.redirectionCallback(true)
                                 return true
                             }

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/form/components/RedirectLine.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/form/components/RedirectLine.kt
@@ -26,7 +26,7 @@ fun RedirectLine(formData: RedirectLineData, viewModel: XS2AWizardViewModel) {
         verticalArrangement = Arrangement.spacedBy(5.dp)
     ) {
         FormButton(label = formData.label!!, buttonStyle = XS2ATheme.CURRENT.redirectButtonStyle) {
-            viewModel.openWebView(formData.url!!)
+            viewModel.openRedirectURL(formData.url!!)
         }
 
         FormButton(

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
@@ -22,6 +22,27 @@ import com.fintecsystems.xs2awizard.components.theme.XS2ATheme
  * Wrapper for the XS2A-Wizard Compose Component
  */
 class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
+    /**
+     * Renders the XS2A-Wizard.
+     *
+     * @param sessionKey - Session key used by the wizard.
+     * @param backendURL - Optional URL to target a different backend.
+     * @param theme - Theme to be used.
+     *                If null the default Light- or Dark-Theme, depending on the device settings, is used.
+     * @param fontResId - Custom typography to be used by all form elements.
+     * @param language - Specifies the wizard language.
+     *                   Defaults to the device language if supported, [XS2AWizardLanguage.EN] otherwise.
+     * @param enableScroll - If true the form container allows for automatic scrolling.
+     *                       Disable if you need to implement nested scrolling.
+     * @param enableBackButton - If true renders back button on some forms.
+     *                           Disable this only if you implement your own back-handling-logic.
+     *                           The user needs to have a way to "go-back".
+     * @param enableAutomaticRetry - If true requests to the backend will be retried if the device is offline and goes online again.
+     *                               This also means that the loading indicator will stay during that time.
+     * @param redirectDeepLink - Deep Link of Host-App used for returning App2App redirection.
+     *                           Must match your scheme and host declared in your AndroidManifest.
+     *                           e.g "<scheme>://<host>".
+     */
     @Suppress("unused")
     constructor(
         sessionKey: String,

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
@@ -32,7 +32,7 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
         enableScroll: Boolean = true,
         enableBackButton: Boolean = true,
         enableAutomaticRetry: Boolean = true,
-        redirectURL: String? = null
+        redirectDeepLink: String? = null
     ) : this() {
         arguments = Bundle().apply {
             putString(XS2AWizardBundleKeys.sessionKey, sessionKey)
@@ -44,7 +44,7 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
             putBoolean(XS2AWizardBundleKeys.enableScroll, enableScroll)
             putBoolean(XS2AWizardBundleKeys.enableBackButton, enableBackButton)
             putBoolean(XS2AWizardBundleKeys.enableAutomaticRetry, enableAutomaticRetry)
-            putString(XS2AWizardBundleKeys.redirectURL, redirectURL)
+            putString(XS2AWizardBundleKeys.redirectDeepLink, redirectDeepLink)
 
             if (fontResId != null) {
                 putInt(XS2AWizardBundleKeys.fontResId, fontResId)
@@ -92,7 +92,7 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
                         enableBackButton = arguments.getBoolean(XS2AWizardBundleKeys.enableBackButton),
                         enableAutomaticRetry = arguments.getBoolean(XS2AWizardBundleKeys.enableAutomaticRetry),
                         callbackListener = this@XS2AWizardFragment,
-                        redirectUrl = arguments.getString(XS2AWizardBundleKeys.redirectURL)
+                        redirectDeepLink = arguments.getString(XS2AWizardBundleKeys.redirectDeepLink)
                     )
                 }
             }

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
@@ -31,7 +31,8 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
         language: XS2AWizardLanguage? = null,
         enableScroll: Boolean = true,
         enableBackButton: Boolean = true,
-        enableAutomaticRetry: Boolean = true
+        enableAutomaticRetry: Boolean = true,
+        redirectURL: String? = null
     ) : this() {
         arguments = Bundle().apply {
             putString(XS2AWizardBundleKeys.sessionKey, sessionKey)
@@ -43,6 +44,7 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
             putBoolean(XS2AWizardBundleKeys.enableScroll, enableScroll)
             putBoolean(XS2AWizardBundleKeys.enableBackButton, enableBackButton)
             putBoolean(XS2AWizardBundleKeys.enableAutomaticRetry, enableAutomaticRetry)
+            putString(XS2AWizardBundleKeys.redirectURL, redirectURL)
 
             if (fontResId != null) {
                 putInt(XS2AWizardBundleKeys.fontResId, fontResId)
@@ -89,7 +91,8 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
                         enableScroll = arguments.getBoolean(XS2AWizardBundleKeys.enableScroll),
                         enableBackButton = arguments.getBoolean(XS2AWizardBundleKeys.enableBackButton),
                         enableAutomaticRetry = arguments.getBoolean(XS2AWizardBundleKeys.enableAutomaticRetry),
-                        callbackListener = this@XS2AWizardFragment
+                        callbackListener = this@XS2AWizardFragment,
+                        redirectUrl = arguments.getString(XS2AWizardBundleKeys.redirectURL)
                     )
                 }
             }

--- a/xs2awizard/src/main/res/values-de/strings.xml
+++ b/xs2awizard/src/main/res/values-de/strings.xml
@@ -24,4 +24,8 @@
     <string name="cancel">Abbrechen</string>
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="server_error">Serverfehler</string>
+    <string name="redirect_dialog_title">Authentifizierungs-Methode wählen</string>
+    <string name="redirect_dialog_message">Wie möchtest du dich einloggen? Hast du die App deiner Bank installiert, wähle \\\"Banking App\\\", andernfalls \\\"Webseite\\\".</string>
+    <string name="redirect_dialog_banking_app_button_title">Banking App</string>
+    <string name="redirect_dialog_website_button_title">Webseite</string>
 </resources>

--- a/xs2awizard/src/main/res/values-de/strings.xml
+++ b/xs2awizard/src/main/res/values-de/strings.xml
@@ -25,7 +25,7 @@
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="server_error">Serverfehler</string>
     <string name="redirect_dialog_title">Authentifizierungs-Methode wählen</string>
-    <string name="redirect_dialog_message">Wie möchtest du dich einloggen? Hast du die App deiner Bank installiert, wähle \\\"Banking App\\\", andernfalls \\\"Webseite\\\".</string>
+    <string name="redirect_dialog_message">Wie möchtest du dich einloggen? Hast du die App deiner Bank installiert, wähle \"Banking App\", andernfalls \"Webseite\".</string>
     <string name="redirect_dialog_banking_app_button_title">Banking App</string>
     <string name="redirect_dialog_website_button_title">Webseite</string>
 </resources>

--- a/xs2awizard/src/main/res/values-es/strings.xml
+++ b/xs2awizard/src/main/res/values-es/strings.xml
@@ -24,4 +24,8 @@
     <string name="fill_credentials_prompt_title">¿Utilizar los datos guardados?</string>
     <string name="no_internet_connection">Sin conexión a Internet</string>
     <string name="server_error">Error de servidor</string>
+    <string name="redirect_dialog_title">Seleccione el método de autenticación</string>
+    <string name="redirect_dialog_message">¿Cómo quiere conectarse? Si ha instalado la aplicación de su banco, seleccione \"Aplicación bancaria\"; de lo contrario, seleccione \"Página web\".</string>
+    <string name="redirect_dialog_banking_app_button_title">Aplicación bancaria</string>
+    <string name="redirect_dialog_website_button_title">Página web</string>
 </resources>

--- a/xs2awizard/src/main/res/values-fr/strings.xml
+++ b/xs2awizard/src/main/res/values-fr/strings.xml
@@ -24,4 +24,8 @@
     <string name="cancel">Annuler</string>
     <string name="no_internet_connection">Pas de connexion Internet</string>
     <string name="server_error">Erreur de serveur</string>
+    <string name="redirect_dialog_title">Sélectionner la méthode d\'authentification</string>
+    <string name="redirect_dialog_message">Comment voulez-vous vous connecter ? Si vous avez installé l\'application de votre banque, sélectionnez \"Application bancaire\", sinon sélectionnez \"Site web\".</string>
+    <string name="redirect_dialog_banking_app_button_title">Application bancaire</string>
+    <string name="redirect_dialog_website_button_title">Site web</string>
 </resources>

--- a/xs2awizard/src/main/res/values-it/strings.xml
+++ b/xs2awizard/src/main/res/values-it/strings.xml
@@ -24,4 +24,8 @@
     <string name="fill_credentials_prompt_title">Usare i dati salvati?</string>
     <string name="no_internet_connection">Nessuna connessione Internet</string>
     <string name="server_error">Errore del server</string>
+    <string name="redirect_dialog_title">Selezionare il metodo di autenticazione</string>
+    <string name="redirect_dialog_message">Come si desidera effettuare il login? Se avete installato l\'applicazione della vostra banca, selezionate \"App bancaria\", altrimenti selezionate \"Sito web\".</string>
+    <string name="redirect_dialog_banking_app_button_title">App bancaria</string>
+    <string name="redirect_dialog_website_button_title">Sito web</string>
 </resources>

--- a/xs2awizard/src/main/res/values/strings.xml
+++ b/xs2awizard/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="no_internet_connection">No Internet Connection</string>
     <string name="server_error">Server Error</string>
     <string name="redirect_dialog_title">Select authentication method</string>
-    <string name="redirect_dialog_message">How do you want to log in? If you have installed your bank\'s app, select \\\"Banking App\\\", otherwise select \\\"Website\\\".</string>
+    <string name="redirect_dialog_message">How do you want to log in? If you have installed your bank\'s app, select \"Banking App\", otherwise select \"Website\".</string>
     <string name="redirect_dialog_banking_app_button_title">Banking App</string>
     <string name="redirect_dialog_website_button_title">Website</string>
 </resources>

--- a/xs2awizard/src/main/res/values/strings.xml
+++ b/xs2awizard/src/main/res/values/strings.xml
@@ -36,4 +36,8 @@
 
     <string name="no_internet_connection">No Internet Connection</string>
     <string name="server_error">Server Error</string>
+    <string name="redirect_dialog_title">Select authentication method</string>
+    <string name="redirect_dialog_message">How do you want to log in? If you have installed your bank\'s app, select \\\"Banking App\\\", otherwise select \\\"Website\\\".</string>
+    <string name="redirect_dialog_banking_app_button_title">Banking App</string>
+    <string name="redirect_dialog_website_button_title">Website</string>
 </resources>


### PR DESCRIPTION
Implemented App2App redirection.

## Integration guide
In your `AndroidManifest.xml` add the following IntentFilter (if not already specified)
Make sure your Activity specifies the arguments `exported` and `launchMode`.

```xml
<activity
    android:exported="true" // Required
    android:launchMode="singleInstance" // Required, other values might be used as well.
    ...>
    ...
    <intent-filter>
        <action android:name="android.intent.action.VIEW" />
        <category android:name="android.intent.category.DEFAULT" />
        <category android:name="android.intent.category.BROWSABLE" />
        <data
            android:host="<host>"
            android:scheme="<scheme>" />
    </intent-filter>
</activity>
```

If done you can pass the deep link as an argument to the Wizard Composable/Fragment constructor.

```kotlin
// Compose
XS2AWizard(
    sessionKey = <your-session-key>,
    redirectDeepLink = "<scheme>://<host>" // Insert your deep link
)

// Fragment
XS2AWizardFragment(
    sessionKey = <your-session-key>,
    redirectDeepLink = "<scheme>://<host>" // Insert your deep link
)
```

Now every time the Wizard tries to redirect the user to a banking login screen, they get asked if they want to stay within the host app and use the internal WebView for the login process or get redirected to an external banking app.
This dialog only appears with Banks known by us to have a Banking App.