### PR TITLE
More fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlin_version = '1.8.10'
-        compose_version = '1.6.7'
+        compose_version = '1.6.6'
     }
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.8.10'
+        kotlin_version = '1.9.23'
         compose_version = '1.6.6'
     }
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 GROUP=com.fintecsystems
-VERSION_NAME=5.2.2
+VERSION_NAME=5.2.3
 POM_URL=https://github.com/FinTecSystems/xs2a-android
 POM_SCM_URL=git@github.com:FinTecSystems/xs2a-android.git
 POM_SCM_CONNECTION=scm:git:git@github.com:FinTecSystems/xs2a-android.git

--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
     // Integration with ViewModels
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.1'
+    implementation 'androidx.fragment:fragment-ktx:1.7.1'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     // Security & EncryptedSharedPreferences
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -41,7 +41,7 @@ android {
         jvmTarget = '11'
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.3'
+        kotlinCompilerExtensionVersion '1.5.11'
     }
 }
 

--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     implementation "androidx.browser:browser:1.8.0"
 
-    implementation "com.fintecsystems:xs2awizard_networking:1.2.0"
+    implementation "com.fintecsystems:xs2awizard_networking:1.2.2"
 }
 
 publishing {

--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.10'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23'
     id 'maven-publish'
     id 'signing'
     id 'kotlin-parcelize'

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/wrappers/XS2AWizardFragment.kt
@@ -6,22 +6,27 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Typography
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelStoreOwner
-import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.fragment.app.activityViewModels
 import com.fintecsystems.xs2awizard.XS2AWizard
-import com.fintecsystems.xs2awizard.components.*
+import com.fintecsystems.xs2awizard.components.XS2AWizardBundleKeys
+import com.fintecsystems.xs2awizard.components.XS2AWizardCallbackListener
+import com.fintecsystems.xs2awizard.components.XS2AWizardError
+import com.fintecsystems.xs2awizard.components.XS2AWizardLanguage
+import com.fintecsystems.xs2awizard.components.XS2AWizardStep
+import com.fintecsystems.xs2awizard.components.XS2AWizardViewModel
 import com.fintecsystems.xs2awizard.components.theme.XS2ATheme
 
 /**
  * Wrapper for the XS2A-Wizard Compose Component
  */
 class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
+    private val xS2AWizardViewModel: XS2AWizardViewModel by activityViewModels()
+
     /**
      * Renders the XS2A-Wizard.
      *
@@ -82,40 +87,37 @@ class XS2AWizardFragment() : Fragment(), XS2AWizardCallbackListener {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
             setContent {
-                CompositionLocalProvider(
-                    LocalViewModelStoreOwner provides (activity as ViewModelStoreOwner)
-                ) {
-                    val arguments = requireArguments()
+                val arguments = requireArguments()
 
-                    assert(arguments.containsKey("sessionKey"))
+                assert(arguments.containsKey("sessionKey"))
 
-                    val typography = if (arguments.containsKey(XS2AWizardBundleKeys.fontResId))
-                        Typography(
-                            defaultFontFamily = FontFamily(
-                                Font(
-                                    arguments.getInt(
-                                        XS2AWizardBundleKeys.fontResId
-                                    )
+                val typography = if (arguments.containsKey(XS2AWizardBundleKeys.fontResId))
+                    Typography(
+                        defaultFontFamily = FontFamily(
+                            Font(
+                                arguments.getInt(
+                                    XS2AWizardBundleKeys.fontResId
                                 )
                             )
                         )
-                    else
-                        MaterialTheme.typography
-
-
-                    XS2AWizard(
-                        sessionKey = arguments.getString(XS2AWizardBundleKeys.sessionKey)!!,
-                        backendURL = arguments.getString(XS2AWizardBundleKeys.backendURL),
-                        theme = arguments.getParcelable(XS2AWizardBundleKeys.theme),
-                        typography = typography,
-                        language = arguments.getSerializable(XS2AWizardBundleKeys.language) as? XS2AWizardLanguage,
-                        enableScroll = arguments.getBoolean(XS2AWizardBundleKeys.enableScroll),
-                        enableBackButton = arguments.getBoolean(XS2AWizardBundleKeys.enableBackButton),
-                        enableAutomaticRetry = arguments.getBoolean(XS2AWizardBundleKeys.enableAutomaticRetry),
-                        callbackListener = this@XS2AWizardFragment,
-                        redirectDeepLink = arguments.getString(XS2AWizardBundleKeys.redirectDeepLink)
                     )
-                }
+                else
+                    MaterialTheme.typography
+
+
+                XS2AWizard(
+                    sessionKey = arguments.getString(XS2AWizardBundleKeys.sessionKey)!!,
+                    backendURL = arguments.getString(XS2AWizardBundleKeys.backendURL),
+                    theme = arguments.getParcelable(XS2AWizardBundleKeys.theme),
+                    typography = typography,
+                    language = arguments.getSerializable(XS2AWizardBundleKeys.language) as? XS2AWizardLanguage,
+                    enableScroll = arguments.getBoolean(XS2AWizardBundleKeys.enableScroll),
+                    enableBackButton = arguments.getBoolean(XS2AWizardBundleKeys.enableBackButton),
+                    enableAutomaticRetry = arguments.getBoolean(XS2AWizardBundleKeys.enableAutomaticRetry),
+                    callbackListener = this@XS2AWizardFragment,
+                    redirectDeepLink = arguments.getString(XS2AWizardBundleKeys.redirectDeepLink),
+                    xs2aWizardViewModel = xS2AWizardViewModel
+                )
             }
         }
     }


### PR DESCRIPTION
- Bumped `xs2awizard_networking` to 1.2.2
  - This should fix an error related to wrongly configured timeouts
- Now using `activityViewModels` of `Fragment` instead of specifying current `Activity` as `LocalViewModelStoreOwner`
  - This may fix an error where the ViewModel cannot be properly accessed after the 5.2.2 dependency upgrade