### PR TITLE
Crypto downgrade

### DIFF
--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.7.1'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     // Security & EncryptedSharedPreferences
-    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("androidx.security:security-crypto:1.0.0")
     implementation("androidx.biometric:biometric:1.2.0-alpha05")
 
     implementation("io.coil-kt:coil-compose:2.2.0")

--- a/xs2awizard/build.gradle
+++ b/xs2awizard/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     // Security & EncryptedSharedPreferences
     implementation("androidx.security:security-crypto:1.0.0")
-    implementation("androidx.biometric:biometric:1.2.0-alpha05")
+    implementation("androidx.biometric:biometric:1.1.0")
 
     implementation("io.coil-kt:coil-compose:2.2.0")
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/components/XS2AWizardViewModel.kt
@@ -499,7 +499,7 @@ class XS2AWizardViewModel(
         Crypto.createEncryptedSharedPreferences(
             context,
             sharedPreferencesFileName,
-            Crypto.createMasterKey(context, masterKeyAlias)
+            masterKeyAlias
         ).edit().apply {
             form.forEach {
                 if (it is CredentialFormLineData && it.isLoginCredential == true) {
@@ -550,7 +550,7 @@ class XS2AWizardViewModel(
         val sharedPreferences = Crypto.createEncryptedSharedPreferences(
             context,
             sharedPreferencesFileName,
-            Crypto.createMasterKey(context, masterKeyAlias)
+            masterKeyAlias
         )
 
         form.value!!.forEach {

--- a/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/helper/Crypto.kt
+++ b/xs2awizard/src/main/java/com/fintecsystems/xs2awizard/helper/Crypto.kt
@@ -8,31 +8,12 @@ import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
 import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 
 /**
  * Helper object for [EncryptedSharedPreferences] related tasks.
  */
 @RequiresApi(Build.VERSION_CODES.M)
 internal object Crypto {
-    /**
-     * Get's or creates a new Master Key to use with [EncryptedSharedPreferences].
-     *
-     * @param context - Context to use.
-     * @param keyAlias - Name of the key.
-     *
-     * @return New or existing Master Key.
-     */
-    fun createMasterKey(context: Context, keyAlias: String): MasterKey =
-        MasterKey.Builder(context, keyAlias).apply {
-            setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            setUserAuthenticationRequired(true)
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                setRequestStrongBoxBacked(true)
-            }
-        }.build()
-
     /**
      * Checks if the device has biometrics and if it's set.
      *
@@ -48,18 +29,18 @@ internal object Crypto {
      *
      * @param context - Context to use.
      * @param fileName - Name of the shared-preferences-file.
-     * @param masterKey - Key do d-/encrypt data.
+     * @param masterKeyAlias - Name of key do d-/encrypt data.
      *
      * @return Created instance.
      */
     fun createEncryptedSharedPreferences(
         context: Context,
         fileName: String,
-        masterKey: MasterKey
+        masterKeyAlias: String
     ) = EncryptedSharedPreferences.create(
-        context,
         fileName,
-        masterKey,
+        masterKeyAlias,
+        context,
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     )


### PR DESCRIPTION
A customer is blocked by the fact we used an alpha version of the `security-crypto` lib and asked us to downgrade to the latest stable version.

This is unfortunate since this means we don't include the latest `Tink` (Googles Cryptography lib) version anymore and don't have access to the Hardware-backed KeyStore found in newer Android devices anymore.

## Changes
- Reverted `androidx.security:security-crypto` to v1.0.0
  - Modified `XS2AWizardViewModel` & `Crypto` to conform to the API-Changes
- Reverted `androidx.biometric:biometric` to v1.1.0 